### PR TITLE
fix(ci): Update GitHub Pages workflow and Node.js version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 permissions:
@@ -22,24 +21,23 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18' # Use a stable LTS version
+          node-version: '22' # Updated Node.js version
           cache: 'npm'
 
       - name: Install Dependencies 🔧
         run: npm install
 
       - name: Build 🏗️
-        # The base path will be set in vite.config.ts
         run: npm run build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5 # Updated version
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3 # Updated version
         with:
           path: './dist'
 
       - name: Deploy to GitHub Pages 🚀
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4 # Updated version


### PR DESCRIPTION
This commit resolves a failure in the GitHub Actions deployment workflow.

- Updates the `actions/configure-pages`, `actions/upload-pages-artifact`, and `actions/deploy-pages` actions to their latest versions to fix deprecation errors.
- Updates the Node.js version used in the workflow from 18 to 22 as requested.